### PR TITLE
Add 13 Sentinels: Aegis Rim

### DIFF
--- a/games.txt
+++ b/games.txt
@@ -24,6 +24,7 @@ CUSA14168_00 # Resident Evil 3
 CUSA09249_00 # Modern Warfare 2 Campaign Remastered
 CUSA12031_00 # Kingdom Hearts III
 CUSA15322_00 # Sid Meier's Civilization VI
+CUSA19620_00 # 13 Sentinels: Aegis Rim
 # Other titles
 CUSA02320_00 # UNCHARTED The Nathan Drake Collection
 CUSA09311_00 # Assassin's Creed Odyssey


### PR DESCRIPTION
13 Sentinels: Aegis Rim (PS4), released in September 2020 in the West, developed by Vanillaware and published by Atlus.