### PR TITLE
Fix file extension in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Games which are supported for [PlayStationDiscord](https://github.com/Tustin/Pla
 ## Adding titles
 
 1. Fork the repo
-2. Modify `games.txt` and add the title id(s) you want (use the same format I used) **Please don't modify `games.json`, this file should be read-only and only modified by the script.**
+2. Modify `games.yml` and add the title id(s) you want (use the same format I used) **Please don't modify `games.json`, this file should be read-only and only modified by the script.**
 3. Open a PR with your changes.
 
 ## Supported Games


### PR DESCRIPTION
To add a game yourself it should be done in the games YAML file and not a txt file right?